### PR TITLE
Add init script to deploy bot stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,38 @@
 # discordbot_coalffj
 Bot discord qui résume les nouveau message du serveur Coalition FFJ et les envois par mail sur coalition_ffj@femmesdedroit.be (mailing list)
 
-
-├─ requirements.txt						(librairies python nécessaires)
-├─ Dockerfile							(configuration du conteneur)
-├─ railway.toml							(configuration railway)
-├─ .env									(variables d'environnement et tokens secret)
+├─ requirements.txt                                             (librairies python nécessaires)
+├─ Dockerfile                                                   (configuration du conteneur)
+├─ railway.toml                                                 (configuration railway)
+├─ .env                                                         (variables d'environnement et tokens secret)
 ├─ bot/
-│	├─ core.py							(script principal)
-│	├─ channel_lists.py					(gestion des canaux importants / exclus)
-│	├─ summarizer.py					(fonctionnalités de résumé)
-│	├─ discord_bot_commands.py			(commandes du bot via Discord)
-│	├─ mails_managment.py				(fonctions pour gérer les envois de mails prod/test)
+│       ├─ core.py                                              (script principal)
+│       ├─ channel_lists.py                                     (gestion des canaux importants / exclus)
+│       ├─ summarizer.py                                        (fonctionnalités de résumé)
+│       ├─ discord_bot_commands.py                              (commandes du bot via Discord)
+│       ├─ mails_managment.py                                   (fonctions pour gérer les envois de mails prod/test)
 │
 ├─ tests/
-│  ├─ test_env.py						(fonctions de tests et controle)
+│  ├─ test_env.py                                               (fonctions de tests et controle)
 │  ├─ test_channel_lists.py
 │  ├─ test_summarizer.py
 │  ├─ test_mails.py
 │  └─ test_bot_integration.py
 │
 ├─ data/
-│   ├─ important_channels.txt			(liste des canaux important - messages intégrals)
-│   ├─ excluded_channels.txt			(liste des canaux non surveillés)
-│   ├─ daily_summary.txt				(daily report)
-│   └─ weekly_summary.txt				(weekly report)
+│   ├─ important_channels.txt                   (liste des canaux important - messages intégrals)
+│   ├─ excluded_channels.txt                    (liste des canaux non surveillés)
+│   ├─ daily_summary.txt                        (daily report)
+│   └─ weekly_summary.txt                       (weekly report)
+├─ init_bot_stack.sh                            (installation rapide de Docker et lancement de la stack)
 
+## Lancement rapide
+
+Sur un Raspberry Pi ou toute machine fraîchement installée :
+
+```bash
+chmod +x init_bot_stack.sh
+./init_bot_stack.sh
+```
+
+Le script installe Docker et docker-compose, clone ce dépôt puis démarre la stack Docker.

--- a/init_bot_stack.sh
+++ b/init_bot_stack.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+
+# Installation des paquets nécessaires
+sudo apt update && sudo apt install -y docker.io docker-compose git
+
+# Clonage du projet
+REPO_URL="https://github.com/seb-baudoux/discord-bot.git"
+TARGET_DIR="discord-bot"
+
+if [ ! -d "$TARGET_DIR" ]; then
+    git clone "$REPO_URL" "$TARGET_DIR"
+fi
+cd "$TARGET_DIR"
+
+# Lancement de la stack
+sudo docker compose up -d --build


### PR DESCRIPTION
## Summary
- add `init_bot_stack.sh` script from the deployment guide
- document quick launch procedure in `README`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68861aa52194832cb1afc4d31889e774

## Résumé par Sourcery

Fournir un script de déploiement en un clic et mettre à jour la documentation pour simplifier l'installation et le lancement de la pile de bots.

Nouvelles fonctionnalités :
- Ajouter `init_bot_stack.sh` pour automatiser l'installation de Docker, le clonage du dépôt et le lancement de la pile

Documentation :
- Ajouter une section de lancement rapide dans le README avec des instructions d'utilisation pour le script d'initialisation

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Provide a one-click deployment script and update documentation to simplify setup and launch of the bot stack.

New Features:
- Add init_bot_stack.sh to automate Docker installation, repository cloning, and stack launch

Documentation:
- Add quick launch section in README with usage instructions for the init script

</details>