### PR TITLE
Add Woodpecker pipeline

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -1,0 +1,18 @@
+pipeline:
+  test:
+    image: python:3.9
+    commands:
+      - pip install -r requirements.txt
+      - python -m unittest discover
+  deploy:
+    image: docker:cli
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    commands:
+      - docker compose down
+      - docker compose build
+      - docker compose up -d
+
+when:
+  event:
+    - push


### PR DESCRIPTION
## Summary
- add Woodpecker CI configuration to run tests and redeploy on push

## Testing
- `python -m unittest discover tests` *(fails: ModuleNotFoundError: No module named 'discord')*

------
https://chatgpt.com/codex/tasks/task_e_68861a7d8350832c884da9b4aef9afd8

## Résumé par Sourcery

CI :
- Ajout de la configuration Woodpecker CI avec des pipelines de test et de déploiement déclenchés lors des événements de push

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Add Woodpecker CI configuration with test and deploy pipelines triggered on push events

</details>