### PR TITLE
Add docker compose stack

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,45 @@
+version: '3.8'
+services:
+  bot:
+    build: ./bot
+    env_file: ./bot/.env
+    restart: always
+
+  gitea:
+    image: gitea/gitea:latest
+    volumes:
+      - ./data/gitea:/data
+    ports:
+      - "3000:3000"
+      - "222:22"
+    restart: always
+
+  woodpecker-server:
+    image: woodpeckerci/woodpecker-server:latest
+    environment:
+      - WOODPECKER_OPEN=true
+      - WOODPECKER_GITEA=true
+      - WOODPECKER_GITEA_URL=http://gitea:3000
+      - WOODPECKER_GITEA_CLIENT=xxx
+      - WOODPECKER_GITEA_SECRET=yyy
+    volumes:
+      - ./data/woodpecker:/var/lib/woodpecker
+    ports:
+      - "8000:8000"
+    restart: always
+
+  woodpecker-agent:
+    image: woodpeckerci/woodpecker-agent:latest
+    environment:
+      - WOODPECKER_SERVER=woodpecker-server:9000
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    restart: always
+
+  uptime-kuma:
+    image: louislam/uptime-kuma:latest
+    ports:
+      - "3001:3001"
+    volumes:
+      - ./monitoring/uptime-kuma:/app/data
+    restart: always


### PR DESCRIPTION
## Summary
- add `docker-compose.yml` to orchestrate bot, Gitea, Woodpecker CI and Uptime Kuma

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for discord.py)*

------
https://chatgpt.com/codex/tasks/task_e_68861a711608832cb7288dbdb486f69a

## Résumé par Sourcery

Nouvelles Fonctionnalités:
- Introduction de docker-compose.yml pour orchestrer le bot, Gitea, le serveur et l'agent Woodpecker CI, et Uptime Kuma

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Introduce docker-compose.yml to orchestrate the bot, Gitea, Woodpecker CI server and agent, and Uptime Kuma

</details>